### PR TITLE
include `CKRecord.RecordType` in deleted record ids

### DIFF
--- a/Sources/CloudSyncSession/CloudKitOperationHandler.swift
+++ b/Sources/CloudSyncSession/CloudKitOperationHandler.swift
@@ -131,7 +131,7 @@ public class CloudKitOperationHandler: OperationHandler {
         var hasMore = false
         var token: CKServerChangeToken? = fetchOperation.changeToken
         var changedRecords: [CKRecord] = []
-        var deletedRecordIDs: [CKRecord.ID] = []
+        var deletedRecordIDs: [CKRecord.RecordType: [CKRecord.ID]] = [:]
 
         let operation = CKFetchRecordZoneChangesOperation()
 
@@ -164,8 +164,12 @@ public class CloudKitOperationHandler: OperationHandler {
             changedRecords.append(record)
         }
 
-        operation.recordWithIDWasDeletedBlock = { recordID, _ in
-            deletedRecordIDs.append(recordID)
+        operation.recordWithIDWasDeletedBlock = { recordID, recordType in
+            if deletedRecordIDs[recordType] != nil {
+                deletedRecordIDs[recordType]?.append(recordID)
+            } else {
+                deletedRecordIDs[recordType] = [recordID]
+            }
         }
 
         operation.recordZoneFetchCompletionBlock = { [weak self] _, newToken, _, newHasMore, _ in

--- a/Sources/CloudSyncSession/SyncWork.swift
+++ b/Sources/CloudSyncSession/SyncWork.swift
@@ -93,7 +93,7 @@ public struct FetchOperation: Identifiable, SyncOperation {
     public struct Response {
         public let changeToken: CKServerChangeToken?
         public let changedRecords: [CKRecord]
-        public let deletedRecordIDs: [CKRecord.ID]
+        public let deletedRecordIDs: [CKRecord.RecordType: [CKRecord.ID]]
         public let hasMore: Bool
     }
 

--- a/Tests/CloudSyncSessionTests/CloudSyncSessionTests.swift
+++ b/Tests/CloudSyncSessionTests/CloudSyncSessionTests.swift
@@ -18,7 +18,7 @@ class SuccessfulMockOperationHandler: OperationHandler {
                     FetchOperation.Response(
                         changeToken: nil,
                         changedRecords: (0 ..< 400).map { _ in makeTestRecord() },
-                        deletedRecordIDs: [],
+                        deletedRecordIDs: [:],
                         hasMore: self.operationCount == 1
                     )
                 )


### PR DESCRIPTION
I found it might be useful to include record type information in deleted records when doing fetch operation, so that once record type is known, we can do operation to that table directly, without maintaining some extra data.

for my use case it's kind of convenient, what do you think?