### PR TITLE
Handling specific subscription type when using shared database

### DIFF
--- a/Sources/CloudSyncSession/CloudKitOperationHandler.swift
+++ b/Sources/CloudSyncSession/CloudKitOperationHandler.swift
@@ -433,10 +433,10 @@ private extension CloudKitOperationHandler {
     }
 
     func createSubscription(zoneID: CKRecordZone.ID, subscriptionID: String, completion: @escaping (Result<Bool, Error>) -> Void) {
-        let subscription = CKRecordZoneSubscription(
-            zoneID: zoneID,
-            subscriptionID: subscriptionID
-        )
+        
+        var subscription: CKSubscription = database.databaseScope == .shared ?
+            CKDatabaseSubscription(subscriptionID: subscriptionID) :
+            CKRecordZoneSubscription(zoneID: zoneID,subscriptionID: subscriptionID)
 
         let notificationInfo = CKSubscription.NotificationInfo()
         notificationInfo.shouldSendContentAvailable = true


### PR DESCRIPTION
Hello! Thanks for this awesome library. I'm using it a lot on my app Fuel Tracker+.
This PR adds support for creating subscription on shared databases, which requires a different method to obtain it.
